### PR TITLE
Addressed email button issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .env
 spotify_lambda/node_modules
 spotify_lambda/function.zip
+.vscode/settings.json
+cypress/downloads

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -83,6 +83,6 @@ describe( 'Home Page', () => {
     cy.get( 'footer' )
       .find( 'a[href="https://github.com/MisterPea"]' );
     cy.get( 'footer' )
-      .find( 'button[class*="render-mail"]' );
+      .find( 'button[class*="render-footer-mail"]' );
   } );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -3692,9 +3692,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,7 +23,7 @@ export default function Footer() {
             </svg>
           </div>
         </a>
-        <button title="Send an email" aria-label="Send email" className="footer-btn render-mail">
+        <button title="Send an email" aria-label="Send email" className="footer-btn render-footer-mail">
           <div className="footer-svg_wrapper email-div">
             <svg data-name="Email" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.02 40.04">
               <path d="M19.44,22.4l-8.9-8.16v12.69h18.96v-12.69l-8.9,8.16c-.33.3-.84.3-1.17,0Z" />

--- a/src/index.11ty.tsx
+++ b/src/index.11ty.tsx
@@ -10,7 +10,7 @@ export function Index() {
         <Header />
         <div className="main_wrapper-home" data-barba="container" data-barba-namespace="home">
             <h1 className="landing-headline">I&apos;m Perry, Design-Minded Developer and Programmatic Pixel Pusher based in Brooklyn, NY.&nbsp;
-                <span><button title="Send an email" aria-label="Send email" className="render-mail">Say Hello!</button></span>
+                <span><button title="Send an email" aria-label="Send email" className="say_hello_btn render-hello-mail">Say Hello!</button></span>
             </h1>
             <section className="landing-projects_section">
                 <SectionDivider label="Selected Works" className="landing-divider" />

--- a/src/js/animations.ts
+++ b/src/js/animations.ts
@@ -20,10 +20,10 @@ export const animationEnterOnce = (container: HTMLElement) => {
   });
   tl.from(".landing-projects_section", {
     opacity: 0,
-    duration: 0.8,
+    duration: 1,
     ease: 'sine.out',
     display: 'none'
-  },('-=0.25'));
+  }, ('-=0.25'));
   tl.from(".main_wrapper-home span",
     {
       opacity: 0,
@@ -32,18 +32,18 @@ export const animationEnterOnce = (container: HTMLElement) => {
     }, ('-=0.7'));
   tl.from(".landing-about_section", {
     opacity: 0,
-    duration: 0.6,
+    duration: 1,
     ease: 'sine.out',
     display: 'none'
   });
   tl.from("header", {
     opacity: 0,
-    duration: 0.8,
+    duration: 1,
     ease: 'sine.out'
   }, ("-=1.2"));
   tl.from("footer", {
     opacity: 0,
-    duration: 0.8,
+    duration: 1,
     ease: 'sine.out',
     display: 'none'
   }, ("-=0.5"));
@@ -53,7 +53,7 @@ export const animationEnterOnce = (container: HTMLElement) => {
 export const animationLeaveUp = (container: HTMLElement) => {
   return gsap.to(container, {
     autoAlpha: 0,
-    duration: 0.8,
+    duration: 1,
     clearProps: 'all',
     ease: 'expo.in',
     yPercent: -10,

--- a/src/js/intersectionFunctions.ts
+++ b/src/js/intersectionFunctions.ts
@@ -8,11 +8,11 @@ const imageObserver = new IntersectionObserver((entries, obs) => {
   });
 }, {
   root: null,
-  rootMargin: '10px',
+  rootMargin: '100px',
   threshold: 0.1,
 });
 
-// Observer for images
+// Observer for video
 const videoObserver = new IntersectionObserver((entries, obs) => {
   entries.forEach((entry: IntersectionObserverEntry) => {
     if (entry.isIntersecting) {

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -1,5 +1,5 @@
 import { addObservers } from "./intersectionFunctions";
-import "./renderEmail";
+import { initFooterButton, initHelloButtonEmail } from "./renderEmail";
 import initParallax from "./parallax";
 import spotifyListening from "./spotifyListening";
 import barba from "@barba/core";
@@ -87,8 +87,9 @@ function initPageListeners(data: BarbaTransitionEvent) {
   addObservers('figure.lazy');
   initParallax();
   if (currPath === '/') {
-    // only load spotify on root & add 
+    // only load spotify on root
     spotifyListening();
+    initHelloButtonEmail();
     homeBtn.classList.remove('enabled');
     if (!homeBtn.classList.contains('disabled')) homeBtn.classList.add('disabled');
   } else {
@@ -97,6 +98,8 @@ function initPageListeners(data: BarbaTransitionEvent) {
     if (!homeBtn.classList.contains('enabled')) homeBtn.classList.add('enabled');
   }
 }
+
+
 
 // fires at every before enter
 barba.hooks.beforeEnter((e: BarbaTransitionEvent) => {
@@ -140,6 +143,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   const lightDarkToggleBtn = document.querySelector('.dark_mode-button');
   if (lightDarkToggleBtn) lightDarkToggleBtn.addEventListener('click', () => toggleDarkMode());
+
+  initFooterButton();
 
   console.log(`%c    Thanks for checking me out!
     Interested in working together?

--- a/src/js/renderEmail.ts
+++ b/src/js/renderEmail.ts
@@ -1,4 +1,4 @@
-function renderEmail() {
+export function renderEmail() {
   const decoded = [];
   const sorted = ' _:!?.@=abceghijJlmnoprstuy';
   const numArray = [
@@ -14,11 +14,26 @@ function renderEmail() {
   return decoded.join('');
 }
 
-const emailBtn = document.querySelectorAll('.render-mail');
-emailBtn.forEach((btn: HTMLButtonElement) => {
-  btn.addEventListener('click', () => {
-    const anchor = document.createElement('a');
-    anchor.href = renderEmail();
-    anchor.click();
+export function initFooterButton() {
+  const footerEmailBtn = document.querySelectorAll('.render-footer-mail');
+  footerEmailBtn.forEach((btn: HTMLButtonElement) => {
+    btn.addEventListener('click', () => {
+      const anchor = document.createElement('a');
+      anchor.href = renderEmail();
+      anchor.click();
+    });
   });
-});
+}
+
+// We have to separate this logic from the footer email because on page transitions we're
+// losing reference to the 'Say Hello!' button (but not the footer)
+export function initHelloButtonEmail() {
+  const helloEmailBtn = document.querySelectorAll('.render-hello-mail');
+  helloEmailBtn.forEach((btn: HTMLButtonElement) => {
+    btn.addEventListener('click', () => {
+      const anchor = document.createElement('a');
+      anchor.href = renderEmail();
+      anchor.click();
+    });
+  });
+}


### PR DESCRIPTION
Moved instantiation of buttons to main index. The footer init only needs to be called once, but the header email must be called on every `/` (root) load because its listener is being destroyed on every navigation away from it (root)